### PR TITLE
Feature - Merge Refs & Ref Cleanup

### DIFF
--- a/packages/zepsh-dom/src/work.js
+++ b/packages/zepsh-dom/src/work.js
@@ -246,5 +246,14 @@ function updateFunctionComponent(fiber) {
  */
 function updateHostComponent(fiber) {
   if (!fiber.dom) fiber.dom = createDom(fiber);
+  if (fiber.props.ref) {
+    // Assign ref to DOM node
+    const ref = fiber.props.ref;
+    if (typeof ref === "function") {
+      ref(fiber.dom);
+    } else if (ref && typeof ref === "object" && "current" in ref) {
+      ref.current = fiber.dom;
+    }
+  }
   reconcileChildren(fiber, fiber.props.children);
 }

--- a/packages/zepsh/index.js
+++ b/packages/zepsh/index.js
@@ -5,8 +5,8 @@
 import { createElement, Fragment, Suspense, ErrorBoundary, memo, Profiler, StrictMode, ViewTransition } from "./src/element";
 import { createContext } from "./src/context";
 import { act } from "./src/testing";
-import { useState, useEffect, useLayoutEffect, useInsertionEffect, useRef, useImperativeHandle, useMemo, useCallback, useReducer, useContext, useDeferredValue, useTransition, useActionState, useOptimistic, useSyncExternalStore, useId, useDebugValue, useErrorBoundary, useLocalStorage, useDebounce, useFetch, use, startTransition, cache } from "./src/hooks";
-import { captureOwnerStack } from "./src/utils";
+import { useState, useEffect, useLayoutEffect, useInsertionEffect, useRef, useRefCleanup, useImperativeHandle, useMemo, useCallback, useReducer, useContext, useDeferredValue, useTransition, useActionState, useOptimistic, useSyncExternalStore, useId, useDebugValue, useErrorBoundary, useLocalStorage, useDebounce, useFetch, use, startTransition, cache } from "./src/hooks";
+import { captureOwnerStack, mergeRefs } from "./src/utils";
 import { lazy } from "./src/lazy";
 
 export const Hooks = {
@@ -15,6 +15,7 @@ export const Hooks = {
   useLayoutEffect,
   useInsertionEffect,
   useRef,
+  useRefCleanup,
   useImperativeHandle,
   useMemo,
   useCallback,
@@ -50,6 +51,7 @@ export const APIs = {
   act,
   cache,
   captureOwnerStack,
+  mergeRefs,
   lazy,
   startTransition,
 };

--- a/packages/zepsh/src/utils.js
+++ b/packages/zepsh/src/utils.js
@@ -19,3 +19,20 @@ export function captureOwnerStack(fiber) {
   }
   return stack.reverse().join(" > ");
 }
+
+/**
+ * Merges multiple refs into a single callback ref.
+ * @param {Array<Function|Object>} refs - Array of refs (callback or RefObject).
+ * @returns {Function} A callback ref that applies all refs.
+ */
+export function mergeRefs(refs) {
+  return (node) => {
+    refs.forEach((ref) => {
+      if (typeof ref === "function") {
+        ref(node);
+      } else if (ref && typeof ref === "object" && "current" in ref) {
+        ref.current = node;
+      }
+    });
+  };
+}


### PR DESCRIPTION
- `zepsh/element`: Ensured `createElement` includes `ref` in `props` without special handling, treating it as a regular prop.
- `zepsh-dom/work`: Added `ref` assignment logic in `updateHostComponent` to handle both callback refs (functions) and `RefObject` (objects with `current`). This ensures `ref` props are applied to DOM nodes during reconciliation.
- `zepsh/utils`: Added `mergeRefs` to combine multiple refs (callback or `RefObject`) into a single callback ref.
- `zepsh/hooks`: Added `useRefCleanup`, which creates a ref and runs a cleanup function on unmount or ref change using `useEffect`.